### PR TITLE
Changing composer create project call

### DIFF
--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -13,7 +13,7 @@ If you have not yet done so, [install Composer](https://getcomposer.org/doc/00-i
 Once you have, use the `create-project` command to create a new application:
 
 ```bash
-$ composer create-project -sdev laminas/skeleton-application my-application
+$ composer create-project -sdev laminas/laminas-mvc-skeleton my-application
 ```
 
 ## Create a New Module


### PR DESCRIPTION
As I finally found time to play with Laminas, I followed the instructions in the quick-start documentation and stumbled against my first issue.

```bash
[InvalidArgumentException]
  Could not find package laminas/skeleton-application with stability dev.
```

When I searched the repository for Laminas and Packagists, I wasn't able to find a project called "skeleton-application". I did discover 2 repos that deal with setting up the skeleton MVC model and I believe that package `laminas/laminas-mvc-skeleton` would be the correct candidate for this.

After using `laminas/laminas-mvc-skeleton` locally, I was presented with a full install of Laminas with all the options I selected. So my assumption is that I made the right change.

Can someone verify and confirm this assumption?
```